### PR TITLE
update version to release rule fix behind feature flag

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ci-test"
-version = "0.0.4"
+version = "0.0.5"
 authors = [
   { name="Evan Kohilas" },
 ]


### PR DESCRIPTION
This PR:

1. creates a release to PyPI (using #11) to publish a new version of ci-test[^1]
2. that supports outputting jobs even if they have no rules (via #9)
3. through using the flag `--flag-output-jobs-with-no-rules` to support breaking changes (by #10)

[^1]: If I understand GitHub correctly